### PR TITLE
chore(release): bump tested up to WordPress 7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,87 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.2.0] - 2026-07-02
+
+### Changed
+
+- Update tested up WordPress version to 7.0.
+
+## [1.1.1] - 2025-12-12
+
+### Fixed
+
+- Fix missing built assets.
+
+## [1.1.0] - 2025-12-01
+
+### Changed
+
+- Update Matterport logo.
+- Update tested up WordPress version to 6.9.
+
+## [1.0.2] - 2025-07-04
+
+### Changed
+
+- Update minimum required version to 5.0. This plugin could work with WordPress 2.9+ but is built for the Block Editor. The plugin also requires at least WordPress 4.6 for modern localization support.
+
+## [1.0.1] - 2025-07-04
+
+### Changed
+
+- Update FAQ and description in documentation.
+- Add missing text domain headers.
+
+### Added
+
+- Add preview blueprint.
+
+## [1.0.0] - 2025-06-26
+
+### Added
+
+- Public release.
+
+## [0.3.0] - 2025-06-26
+
+### Added
+
+- Add GitHub workflows to deploy and release the plugin on WordPress.org SVN repository.
+
+## [0.2.2]
+
+### Changed
+
+- Update `readme.txt` with "Screenshots" section.
+- Move all assets into `.wordpress-org` folder.
+
+## [0.2.1]
+
+### Changed
+
+- Rename plugin name, slug and namespace.
+- Update plugin description.
+- Rename block variation title.
+
+### Added
+
+- Add missing icon and screenshot.
+
+## [0.2.0] - 2025-06-16
+
+### Changed
+
+- Rename plugin name, slug and namespace.
+
+## [0.1.0] - 2025-06-03
+
+### Added
+
+- Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
 ## [1.2.0] - 2026-07-02
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For more information about Matterport models and embedding options, visit the [o
 
 -   WordPress 2.9 or higher
 -   PHP 7.1 or higher
--   Tested up to WordPress 6.9
+-   Tested up to WordPress 7.0
 
 ## Frequently Asked Questions
 
@@ -73,49 +73,4 @@ If your page builder supports oEmbed, it should work because Matterport is added
 
 ## Changelog
 
-### 1.1.1
-
--   Fix missing built assets.
-
-### 1.1.0
-
--   Update Matterport logo.
--   Update tested up WordPress version to 6.9.
-
-### 1.0.2
-
--   Update minimum required version to 5.0. This plugin could work with WordPress 2.9+ but is built for the Block Editor. The plugin also requires at least WordPress 4.6 for modern localization support.
-
-### 1.0.1
-
--   Update FAQ and description in documentation.
--   Add missing text domain headers.
--   Add preview blueprint.
-
-### 1.0.0
-
--   Public release.
-
-### 0.3.0
-
--   Add GitHub workflows to deploy and release the plugin on WordPress.org SVN repository.
-
-### 0.2.2
-
--   Update `readme.txt` with "Screenshots" section.
--   Move all assets into `.wordpress-org` folder.
-
-### 0.2.1
-
--   Rename plugin name, slug and namespace.
--   Update plugin description.
--   Rename block variation title.
--   Add missing icon and screenshot.
-
-### 0.2.0
-
--   Rename plugin name, slug and namespace.
-
-### 0.1.0
-
--   Initial release.
+See [CHANGELOG.md](CHANGELOG.md) for release history.

--- a/embed-block-for-matterport.php
+++ b/embed-block-for-matterport.php
@@ -9,7 +9,7 @@
  *
  * @wordpress-plugin
  * Plugin Name:       Embed Block for Matterport
- * Version:           1.1.1
+ * Version:           1.2.0
  * Plugin URI:        https://github.com/alexandrebuffet/embed-block-for-matterport
  * Description:       Adds Matterport oEmbed support and provides a new Embed block variation.
  * Author:            Alexandre Buffet

--- a/readme.txt
+++ b/readme.txt
@@ -5,8 +5,8 @@ Tags:              matterport, oembed, embed, 3d, virtual model
 Contributors:      alexandrebuffet, bsaweb, sebastienserre
 Requires at least: 5.0
 Requires PHP:      7.1
-Tested up to:      6.9
-Stable tag:        1.1.1
+Tested up to:      7.0
+Stable tag:        1.2.0
 Text Domain:       embed-block-for-matterport
 License:           GPLv2
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html
@@ -70,6 +70,10 @@ If your page builder supports oEmbed, it should work because Matterport is added
 1. Matterport model embed in block editor.
 
 == Changelog ==
+
+= 1.2.0 =
+
+-   Update tested up WordPress version to 7.0.
 
 = 1.1.1 =
 


### PR DESCRIPTION
## Summary

- Bump plugin version to 1.2.0 and update `Tested up to` to WordPress 7.0.
- Add `CHANGELOG.md` (Keep a Changelog format) and move release history out of `README.md`.
- Update `readme.txt` changelog with a new 1.2.0 section above 1.1.1.

## Test plan

- [x] `composer phpcs` (pre-existing warnings on generated `build/block-editor.asset.php` only)
- [x] `npm run lint:js`
- [x] `npm run build`
- [x] `ddev wp plugin check embed-block-for-matterport` (no new errors; pre-existing hidden-files notices on `.gitignore` / `.distignore`)
- [x] Plugin active at 1.2.0 on DDEV WordPress 7.0
- [x] Matterport oEmbed provider registered
- [x] Block editor build assets present

## Post-merge

Tag `1.2.0` to trigger SVN deploy and GitHub release.